### PR TITLE
Allow stop/start of the token tracker

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,12 @@ class TokenTracker extends SafeEventEmitter {
       })
   }
 
-  stop(){
+  start() {
+    this.running = true
+    this.blockTracker.on('latest', this.updateBalances)
+  }
+
+  stop() {
     this.running = false
     this.blockTracker.removeListener('latest', this.updateBalances)
   }


### PR DESCRIPTION
This is part of the fix needed for https://github.com/brave/brave-browser/issues/13777
